### PR TITLE
fix prop name typo

### DIFF
--- a/src/components/DatetimePicker.vue
+++ b/src/components/DatetimePicker.vue
@@ -125,7 +125,7 @@
       if (this.datetime instanceof Date) {
         this.selectedDatetime = this.datetime
       } else if (this.datetime instanceof String) {
-        this.selectedDatetime = moment(this.datetimeString, this.format)
+        this.selectedDatetime = moment(this.datetime, this.format)
       }
     },
     computed: {


### PR DESCRIPTION
Small fix, I suppose this should be "datetime" as there is no other reference to "datetimeString" in the code.