### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ yarn add vuetify-datetime-picker
 
 ```js
 import Vue from 'vue'
-import DatetimePicker from 'vuetify-datetime-picker'
+import DatetimePicker from 'vuetify-datetime-picker/src/'
 import 'vuetify-datetime-picker/src/stylus/main.styl'
 
 Vue.use(DatetimePicker)


### PR DESCRIPTION
Pointing to /src/ prevents working around "vuetify.js" and allows vuetify-loader to import necessary components