### PR TITLE
fixed issue #38: v-time-picker with full vuetify import

### DIFF
--- a/src/components/DatetimePicker.vue
+++ b/src/components/DatetimePicker.vue
@@ -40,7 +40,7 @@
               class="v-time-picker-custom"
               v-model="time"
               v-bind="timePickerProps"
-              full-width
+              style="min-width: 100%"
             ></v-time-picker>
           </v-tab-item>
         </v-tabs>


### PR DESCRIPTION
fixed issue #38 with v-time-picker component not being rendered correctly using full vuetify import.
instead of "full-width" use style="min-width: 100%" in v-time-picker.