### PR TITLE
Fix for Issue #38.

### DIFF
--- a/src/components/DatetimePicker.vue
+++ b/src/components/DatetimePicker.vue
@@ -134,21 +134,8 @@ export default {
       time: DEFAULT_TIME
     }
   },
-  created() {
-    if (!this.datetime) {
-      return
-    }
-
-    let initDateTime
-    if (this.datetime instanceof Date) {
-      initDateTime = this.datetime
-    } else if (typeof this.datetime === 'string' || this.datetime instanceof String) {
-      // see https://stackoverflow.com/a/9436948
-      initDateTime = parse(this.datetime, this.dateTimeFormat, new Date())
-    }
-
-    this.date = format(initDateTime, DEFAULT_DATE_FORMAT)
-    this.time = format(initDateTime, DEFAULT_TIME_FORMAT)
+  mounted() {
+    this.init();
   },
   computed: {
     dateTimeFormat() {
@@ -195,6 +182,27 @@ export default {
     },
     showTimePicker() {
       this.activeTab = 1
+    },
+    init() {
+      if (!this.datetime) {
+        return
+      }
+
+      let initDateTime
+      if (this.datetime instanceof Date) {
+        initDateTime = this.datetime;
+      } else if (typeof this.datetime === 'string' || this.datetime instanceof String) {
+        // see https://stackoverflow.com/a/9436948
+        initDateTime = parse(this.datetime, this.dateTimeFormat, new Date());
+      }
+
+      this.date = format(initDateTime, DEFAULT_DATE_FORMAT);
+      this.time = format(initDateTime, DEFAULT_TIME_FORMAT);
+    }
+  },
+  watch: {
+    datetime: function(el) {
+      this.init();
     }
   }
 }

--- a/src/components/DatetimePicker.vue
+++ b/src/components/DatetimePicker.vue
@@ -39,8 +39,16 @@
               ref="timer"
               class="v-time-picker-custom"
               v-model="time"
-              v-bind="timePickerProps"
-              full-width
+              :picker="timePickerProps.picker"
+              :disabled="timePickerProps.disabled"
+              :readonly="timePickerProps.readonly"
+              :landscape="timePickerProps.landscape"
+              :ampmInTitle="timePickerProps.ampmInTitle"
+              :useSeconds="timePickerProps.useSeconds"
+              :format="timePickerProps.format"
+              :noTitle="timePickerProps.noTitle"
+              :scrollable="timePickerProps.scrollable"
+              style="min-width: 100%;"
             ></v-time-picker>
           </v-tab-item>
         </v-tabs>


### PR DESCRIPTION
Fix for Issue #38. VTimePicker handles Props differently than VDatePicker which results in props not being propagated properly to sub-components. 

Workaround: Specify attribute bindings explicitly. 


If full-width attribute is set, the component does not render properly in v-tabs components. 

Workaround: replace full-width attribute with style="min-width: 100px;".